### PR TITLE
Fix toml example/template syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.toml.template linguist-language=TOML
+*.toml.example linguist-language=TOML


### PR DESCRIPTION
With this change these files will be highlighted as if they are normal `.toml` files.